### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ guessed correctly.
 The goal is to use a provided API to play Hangman effectively and
 efficiently. In particular, it is important to implement a modular
 design that will accomodate "pluggable" strategies in order to support
-comparitive exploration of various computer models that play the game
+comparative exploration of various computer models that play the game
 autonomously. Every word will be an entry found in a given text
 file database of all possible words, ```words.txt```.
 


### PR DESCRIPTION
@danlentz, I've corrected a typographical error in the documentation of the [clj-hangman](https://github.com/danlentz/clj-hangman) project. Specifically, I've changed comparitive to comparative. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
